### PR TITLE
set permissions

### DIFF
--- a/x3mRouting.sh
+++ b/x3mRouting.sh
@@ -353,7 +353,6 @@ Check_Files_For_Entries() {
         printf '%s\n' "#!/bin/sh"
         printf '%s\n' "$IPTABLES_ENTRY" # file does not exist, create VPNC_UP_FILE
       } >"$VPNC_UP_FILE"
-      chmod 755 "$VPNC_UP_FILE"
       logger -st "($(basename "$0"))" $$ "$IPTABLES_ENTRY added to $VPNC_UP_FILE"
     fi
   done
@@ -370,7 +369,6 @@ Check_Files_For_Entries() {
       printf '%s\n' "#!/bin/sh"
       printf '%s\n' "$IPTABLES_DEL_ENTRY" # file does not exist, create VPNC_UP_FILE
     } >"$VPNC_DOWN_FILE"
-    chmod 755 "$VPNC_DOWN_FILE"
     logger -st "($(basename "$0"))" $$ "$IPTABLES_DEL_ENTRY added to $VPNC_DOWN_FILE"
   fi
 
@@ -386,10 +384,13 @@ Check_Files_For_Entries() {
       printf '%s\n' "#!/bin/sh"
       printf '%s\n' "$SCRIPT_ENTRY" # file does not exist, create VPNC_UP_FILE
     } >"$NAT_START"
-    chmod 755 "$NAT_START"
     logger -st "($(basename "$0"))" $$ "$SCRIPT_ENTRY added to $NAT_START"
   fi
 
+#set permissions for each file
+if [ -s "$VPNC_UP_FILE" ] && chmod 755 "$VPNC_UP_FILE"
+if [ -s "$VPNC_DOWN_FILE" ] && chmod 755 "$VPNC_DOWN_FILE"
+if [ -s "$NAT_START" ] && chmod 755 "$NAT_START"
 }
 
 Process_Src_Option() {


### PR DESCRIPTION
The problem was if the file is already there and doesn't have the permissions. The old scenario didn't take this into account and didn't set the permission (which was my case, don't know why, maybe because the script incorrectly set them).
In this case we set them always, even if the file exists.
Removed from inside each file "if", to avoiding running them inside the loop.