### PR TITLE
Update policy rules

### DIFF
--- a/x3mRouting.sh
+++ b/x3mRouting.sh
@@ -908,8 +908,8 @@ VPN_Server_to_VPN_Client() {
   VPNC_UP_FILE="/jffs/scripts/x3mRouting/vpnclient${VPN_CLIENT_INSTANCE}-route-up"
   VPNC_DOWN_FILE="/jffs/scripts/x3mRouting/vpnclient${VPN_CLIENT_INSTANCE}-route-pre-down"
   NAT_START="/jffs/scripts/nat-start"
-  POLICY_RULE_WITHOUT_NAME="${VPN_SERVER_SUBNET}>0.0.0.0>VPN"
-  POLICY_RULE="<VPN Server ${VPN_SERVER_INSTANCE}>${VPN_SERVER_SUBNET}>0.0.0.0>VPN"
+  POLICY_RULE_WITHOUT_NAME="${VPN_SERVER_SUBNET}>>VPN"
+  POLICY_RULE="<VPN Server ${VPN_SERVER_INSTANCE}>${VPN_SERVER_SUBNET}>>VPN"
 
   VPN_IP_LIST="$(nvram get vpn_client"$VPN_CLIENT_INSTANCE"_clientlist)"
   for n in 1 2 3 4 5; do
@@ -1033,7 +1033,7 @@ VPN_Server_to_VPN_Client() {
 
     # nvram get vpn_client"${VPN_CLIENT_INSTANCE}"_clientlist
     if [ "$(echo "$VPN_IP_LIST" | grep -c "$POLICY_RULE")" -eq "1" ]; then
-      VPN_IP_LIST="$(echo "$VPN_IP_LIST" | sed "s,<VPN Server ${VPN_SERVER_INSTANCE}>${VPN_SERVER_SUBNET}>0.0.0.0>VPN,,")"
+      VPN_IP_LIST="$(echo "$VPN_IP_LIST" | sed "s,<VPN Server ${VPN_SERVER_INSTANCE}>${VPN_SERVER_SUBNET}>>VPN,,")"
       if [ "$(uname -m)" = "aarch64" ]; then
         low=0
         max=255


### PR DESCRIPTION
removing 0.0.0.0 will save 7 bytes each line for nvram var (took the ideia from RMerlin latest commit)