### PR TITLE
make install general

### DIFF
--- a/Install_x3mRouting.sh
+++ b/Install_x3mRouting.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-nvrgetbuild=$(nvram get buildno)
-buildno=$(echo "$nvrgetbuild" | sed 's/\.//')
+buildno=$(nvram get buildno | sed 's/\.//')
 if [ "$buildno" -lt 38419 ]; then
   branch="master"
   echo "Installing old x3mRouting version"

--- a/Install_x3mRouting.sh
+++ b/Install_x3mRouting.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
+
+nvrgetbuild=$(nvram get buildno)
+buildno=$(echo "$nvrgetbuild" | sed 's/\.//')
+if [ "$buildno" -lt 38419 ]; then
+  branch="master"
+  echo "Installing old x3mRouting version"
+else
+  branch="x3mRouting-384.19"
+  echo "Installing NG x3mRouting version"
+fi
 while true; do
   echo "Downloading, please wait patiently..."
   mkdir -p /jffs/addons/x3mRouting
-  /usr/sbin/curl -s --retry 3 https://raw.githubusercontent.com/Xentrk/x3mRouting/master/x3mRouting_Menu.sh -o /jffs/addons/x3mRouting/x3mRouting_Menu.sh
+  /usr/sbin/curl -s --retry 3 https://raw.githubusercontent.com/Xentrk/x3mRouting/$branch/x3mRouting_Menu.sh -o /jffs/addons/x3mRouting/x3mRouting_Menu.sh
   chmod 755 /jffs/addons/x3mRouting/x3mRouting_Menu.sh
   # Remove old link or alias if exist
   if [ "$(/opt/bin/find /opt/bin/ -maxdepth 1 -type l -ls | grep -c "/opt/bin/x3mRouting -> /jffs/scripts/x3mRouting/x3mRouting.sh")" -eq 0 ]; then


### PR DESCRIPTION
This way, you can use the same install link to install both new and old version.
This way, when final Merlin release (with the vpn changes) is released, when people install x3mRouting, they'll be automatically redirected to the proper install script.

You will have to mantain both branches - one for pre-vpn changes, and the new one for after-vpn changes.

You'll have to talk also with thelonelycoder so amtm can check for updates for the two branches